### PR TITLE
catch HTTP Codes 400 & 401 as BringAuthExceptions

### DIFF
--- a/src/python_bring_api/bring.py
+++ b/src/python_bring_api/bring.py
@@ -79,7 +79,7 @@ class Bring:
                 except JSONDecodeError:
                     _LOGGER.error(f'Exception: Cannot parse login request response:\n{traceback.format_exc()}')
                 else:
-                    _LOGGER.error(f'Exception: Cannot login: {errmsg['message']}') 
+                    _LOGGER.error(f'Exception: Cannot login: {errmsg["message"]}') 
                 raise BringAuthException('Login failed due to authorization failure, please check your email and password.') from e
             elif e.response.status_code == 400:
                 _LOGGER.error(f'Exception: Cannot login: {e.response.text}') 

--- a/src/python_bring_api/bring.py
+++ b/src/python_bring_api/bring.py
@@ -73,9 +73,13 @@ class Bring:
             r = requests.post(f'{self.url}bringauth', data=data)
             r.raise_for_status()
         except RequestException as e:
-            if e.response.status_code == 401: 
-                errmsg = e.response.json()
-                _LOGGER.error(f'Exception: Cannot login: {errmsg['message']}') 
+            if e.response.status_code == 401:
+                try:
+                    errmsg = e.response.json()
+                except JSONDecodeError:
+                    _LOGGER.error(f'Exception: Cannot parse login request response:\n{traceback.format_exc()}')
+                else:
+                    _LOGGER.error(f'Exception: Cannot login: {errmsg['message']}') 
                 raise BringAuthException('Login failed due to authorization failure, please check your email and password.') from e
             elif e.response.status_code == 400:
                 _LOGGER.error(f'Exception: Cannot login: {e.response.text}') 

--- a/src/python_bring_api/bring.py
+++ b/src/python_bring_api/bring.py
@@ -73,8 +73,16 @@ class Bring:
             r = requests.post(f'{self.url}bringauth', data=data)
             r.raise_for_status()
         except RequestException as e:
-            _LOGGER.error(f'Exception: Cannot login:\n{traceback.format_exc()}')
-            raise BringRequestException(f'Authentication failed due to request exception.') from e
+            if e.response.status_code == 401: 
+                errmsg = e.response.json()
+                _LOGGER.error(f'Exception: Cannot login: {errmsg['message']}') 
+                raise BringAuthException('Login failed due to authorization failure, please check your email and password.') from e
+            elif e.response.status_code == 400:
+                _LOGGER.error(f'Exception: Cannot login: {e.response.text}') 
+                raise BringAuthException('Login failed due to bad request, please check your email.') from e
+            else:
+                _LOGGER.error(f'Exception: Cannot login:\n{traceback.format_exc()}')
+                raise BringRequestException(f'Authentication failed due to request exception.') from e
         
         try:
             data = r.json()


### PR DESCRIPTION
The Bring API returns different HTTP error codes on authentication errors (400 when sending an invalid mail, 401 when mail and password do not match).

Because requests already raised exceptions for these status codes, authentication errors were raised as BringRequestException instead of BringAuthExpection.

