### PR TITLE
add notification method to send push notifications to other list members

### DIFF
--- a/src/python_bring_api/bring.py
+++ b/src/python_bring_api/bring.py
@@ -5,7 +5,7 @@ from requests.exceptions import JSONDecodeError
 from requests.models import Response
 from typing import Dict
 
-from .types import NOTIFICATION_TYPE, BringAuthResponse, BringItemsResponse, BringListResponse, BringListItemsDetailsResponse
+from .types import BringNotificationType, BringAuthResponse, BringItemsResponse, BringListResponse, BringListItemsDetailsResponse
 from .exceptions import BringAuthException, BringRequestException, BringParseException
 
 import logging
@@ -88,7 +88,7 @@ class Bring:
             raise BringAuthException('Login failed due to missing data in the API response, please check your email and password.')
         
         self.uuid = data['uuid']
-        self.publicUuid = data.get('publicUuid', "")
+        self.publicUuid = data.get('publicUuid', '')
         self.headers['X-BRING-USER-UUID'] = self.uuid
         self.headers['Authorization'] = f'Bearer {data["access_token"]}'
         self.putHeaders = {
@@ -297,7 +297,7 @@ class Bring:
             raise BringRequestException(f'Removing item {itemName} from list {listUuid} failed due to request exception.') from e
 
 
-    def notify(self, listUuid: str, notificationType: NOTIFICATION_TYPE, itemName: str = None) -> Response:
+    def notify(self, listUuid: str, notificationType: BringNotificationType, itemName: str = None) -> Response:
         """
         Send a push notification to all other members of a shared list.
 
@@ -305,9 +305,9 @@ class Bring:
         ----------
         listUuid : str
             A list uuid returned by loadLists()
-        notificationType : NOTIFICATION_TYPE
+        notificationType : BringNotificationType
         itemName : str, optional
-            The text that **must** be included in the URGENT_MESSAGE.
+            The text that **must** be included in the URGENT_MESSAGE BringNotificationType.
 
         Returns
         -------
@@ -321,23 +321,23 @@ class Bring:
         """
 
         json = {
-            "arguments": [],
-            "listNotificationType": notificationType,
-            "senderPublicUserUuid": self.publicUuid
+            'arguments': [],
+            'listNotificationType': notificationType.value,
+            'senderPublicUserUuid': self.publicUuid
         }
 
-        if not isinstance(notificationType, NOTIFICATION_TYPE):
+        if not isinstance(notificationType, BringNotificationType):
             _LOGGER.error(f'Exception: notificationType {notificationType} not supported.')
-            raise ValueError(f'notificationType {notificationType} not supported, must be of type NOTIFICATION_TYPE.')
-        if notificationType == "URGENT_MESSAGE":
+            raise ValueError(f'notificationType {notificationType} not supported, must be of type BringNotificationType.')
+        if notificationType is BringNotificationType.URGENT_MESSAGE:
             if not itemName or len(itemName) == 0 :
-                _LOGGER.error('Exception: argument itemName missing.')
+                _LOGGER.error('Exception: Argument itemName missing.')
                 raise ValueError('notificationType is URGENT_MESSAGE but argument itemName missing.')
             else:
-                json["arguments"] = [itemName]
+                json['arguments'] = [itemName]
 
-        headers=self.putHeaders
-        headers["Content-Type"] = "application/json; charset=UTF-8"
+        headers = self.putHeaders
+        headers['Content-Type'] = 'application/json; charset=UTF-8'
         try:
             r = requests.post(f'{self.url}bringnotifications/lists/{listUuid}', headers=headers, json=json)
             r.raise_for_status()

--- a/src/python_bring_api/bring.py
+++ b/src/python_bring_api/bring.py
@@ -5,7 +5,7 @@ from requests.exceptions import JSONDecodeError
 from requests.models import Response
 from typing import Dict
 
-from .types import BringAuthResponse, BringItemsResponse, BringListResponse, BringListItemsDetailsResponse
+from .types import NOTIFICATION_TYPE, BringAuthResponse, BringItemsResponse, BringListResponse, BringListItemsDetailsResponse
 from .exceptions import BringAuthException, BringRequestException, BringParseException
 
 import logging
@@ -21,6 +21,7 @@ class Bring:
         self.mail = mail
         self.password = password
         self.uuid = ''
+        self.publicUuid = ''
 
         self.url = 'https://api.getbring.com/rest/v2/'
 
@@ -87,6 +88,7 @@ class Bring:
             raise BringAuthException('Login failed due to missing data in the API response, please check your email and password.')
         
         self.uuid = data['uuid']
+        self.publicUuid = data.get('publicUuid', "")
         self.headers['X-BRING-USER-UUID'] = self.uuid
         self.headers['Authorization'] = f'Bearer {data["access_token"]}'
         self.putHeaders = {
@@ -293,3 +295,53 @@ class Bring:
         except RequestException as e:
             _LOGGER.error(f'Exception: Could not remove item {itemName} from list {listUuid}:\n{traceback.format_exc()}')
             raise BringRequestException(f'Removing item {itemName} from list {listUuid} failed due to request exception.') from e
+
+
+    def notify(self, listUuid: str, notificationType: NOTIFICATION_TYPE, itemName: str = None) -> Response:
+        """
+        Send a push notification to all other members of a shared list.
+
+        Parameters
+        ----------
+        listUuid : str
+            A list uuid returned by loadLists()
+        notificationType : NOTIFICATION_TYPE
+        itemName : str, optional
+            The text that **must** be included in the URGENT_MESSAGE.
+
+        Returns
+        -------
+        Response
+            The server response object.
+
+        Raises
+        ------
+        BringRequestException
+            If the request fails.
+        """
+
+        json = {
+            "arguments": [],
+            "listNotificationType": notificationType,
+            "senderPublicUserUuid": self.publicUuid
+        }
+
+        if not isinstance(notificationType, NOTIFICATION_TYPE):
+            _LOGGER.error(f'Exception: notificationType {notificationType} not supported.')
+            raise ValueError(f'notificationType {notificationType} not supported, must be of type NOTIFICATION_TYPE.')
+        if notificationType == "URGENT_MESSAGE":
+            if not itemName or len(itemName) == 0 :
+                _LOGGER.error('Exception: argument itemName missing.')
+                raise ValueError('notificationType is URGENT_MESSAGE but argument itemName missing.')
+            else:
+                json["arguments"] = [itemName]
+
+        headers=self.putHeaders
+        headers["Content-Type"] = "application/json; charset=UTF-8"
+        try:
+            r = requests.post(f'{self.url}bringnotifications/lists/{listUuid}', headers=headers, json=json)
+            r.raise_for_status()
+            return r
+        except RequestException as e:
+            _LOGGER.error(f'Exception: Could not send notification {notificationType} for list {listUuid}:\n{traceback.format_exc()}')
+            raise BringRequestException(f'Sending notification {notificationType} for list {listUuid} failed due to request exception.') from e

--- a/src/python_bring_api/types.py
+++ b/src/python_bring_api/types.py
@@ -1,6 +1,19 @@
 from typing import TypedDict
 from typing import List
+from enum import Enum
 
+class NOTIFICATION_TYPE(Enum):
+    """Notification type
+    
+    GOING_SHOPPING: "I'm going shopping! - Last chance for adjustments"
+    CHANGED_LIST: "List changed - Check it out"
+    SHOPPING_DONE: "Shopping done - you can relax"
+    URGENT_MESSAGE: "Breaking news - Please get {itemName}! 
+    """
+    GOING_SHOPPING = "GOING_SHOPPING"
+    CHANGED_LIST = "CHANGED_LIST"
+    SHOPPING_DONE = "SHOPPING_DONE"
+    URGENT_MESSAGE = "URGENT_MESSAGE"
 
 class BringList(TypedDict):
     """A list class. Represents a single list."""

--- a/src/python_bring_api/types.py
+++ b/src/python_bring_api/types.py
@@ -2,19 +2,6 @@ from typing import TypedDict
 from typing import List
 from enum import Enum
 
-class NOTIFICATION_TYPE(Enum):
-    """Notification type
-    
-    GOING_SHOPPING: "I'm going shopping! - Last chance for adjustments"
-    CHANGED_LIST: "List changed - Check it out"
-    SHOPPING_DONE: "Shopping done - you can relax"
-    URGENT_MESSAGE: "Breaking news - Please get {itemName}! 
-    """
-    GOING_SHOPPING = "GOING_SHOPPING"
-    CHANGED_LIST = "CHANGED_LIST"
-    SHOPPING_DONE = "SHOPPING_DONE"
-    URGENT_MESSAGE = "URGENT_MESSAGE"
-
 class BringList(TypedDict):
     """A list class. Represents a single list."""
 
@@ -69,3 +56,16 @@ class BringItemsResponse(TypedDict):
 class BringListItemsDetailsResponse(List[BringListItemDetails]):
     """A response class of a list of item details."""
     pass
+
+class BringNotificationType(Enum):
+    """Notification type
+    
+    GOING_SHOPPING: "I'm going shopping! - Last chance for adjustments"
+    CHANGED_LIST: "List changed - Check it out"
+    SHOPPING_DONE: "Shopping done - you can relax"
+    URGENT_MESSAGE: "Breaking news - Please get {itemName}! 
+    """
+    GOING_SHOPPING = "GOING_SHOPPING"
+    CHANGED_LIST = "CHANGED_LIST"
+    SHOPPING_DONE = "SHOPPING_DONE"
+    URGENT_MESSAGE = "URGENT_MESSAGE"


### PR DESCRIPTION
sends mobile push notifications to other members of a shared shopping list. There are 4 types of notifications available in Bring, 

![image](https://github.com/eliasball/python-bring-api/assets/4445816/b518bc5b-d868-4407-94c9-0d4ebe9715e7)
