### PR TITLE
fix encoding for request body

### DIFF
--- a/src/python_bring_api/bring.py
+++ b/src/python_bring_api/bring.py
@@ -239,7 +239,12 @@ class Bring:
             If the request fails.
         """
         try:
-            r = requests.put(f'{self.url}bringlists/{listUuid}', headers=self.putHeaders, data=f'&purchase={itemName}&recently=&specification={specification}&remove=&sender=null')
+            r = requests.put(f'{self.url}bringlists/{listUuid}', headers=self.putHeaders, data={
+                "uuid": listUuid,
+                "purchase": itemName, 
+                "recently": None, 
+                "specification": specification,
+            })
             r.raise_for_status()
             return r
         except RequestException as e:
@@ -271,7 +276,12 @@ class Bring:
             If the request fails.
         """
         try:
-            r = requests.put(f'{self.url}bringlists/{listUuid}', headers=self.putHeaders, data=f'&uuid={listUuid}&purchase={itemName}&specification={specification}')
+            r = requests.put(f'{self.url}bringlists/{listUuid}', headers=self.putHeaders, data={
+                "uuid": listUuid,
+                "purchase": itemName, 
+                "specification": specification,
+            })
+
             r.raise_for_status()
             return r
         except RequestException as e:
@@ -301,7 +311,10 @@ class Bring:
             If the request fails.
         """
         try:
-            r = requests.put(f'{self.url}bringlists/{listUuid}', headers=self.putHeaders, data=f'&purchase=&recently=&specification=&remove={itemName}&sender=null')
+            r = requests.put(f'{self.url}bringlists/{listUuid}', headers=self.putHeaders, data={
+                "remove": itemName, 
+            })
+
             r.raise_for_status()
             return r
         except RequestException as e:
@@ -332,7 +345,10 @@ class Bring:
             If the request fails.
         """
         try:
-            r = requests.put(f'{self.url}bringlists/{listUuid}', headers=self.putHeaders, data=f'&uuid={listUuid}&recently={itemName}')
+            r = requests.put(f'{self.url}bringlists/{listUuid}', headers=self.putHeaders, data={
+                "uuid": listUuid,
+                "recently": itemName, 
+            })
             r.raise_for_status()
             return r
         except RequestException as e:


### PR DESCRIPTION
This should fix a problem with encoding for special characters. Using the `request(... , body=f"my_data")` of the lib requests unfortunately encodes the data in `latin-1` instead of `utf-8`, and therefore breaks the implementation.

Example result for test label: `Milkä`:
<img width="260" alt="Bildschirmfoto 2024-02-01 um 20 49 12" src="https://github.com/eliasball/python-bring-api/assets/7894569/a27e8d2d-ebad-49b7-94d0-e78e2f7eb1aa">

More information about the requests behaviour can be found here: https://github.com/psf/requests/issues/4503