### PR TITLE
Add support for authentication with access token 

### DIFF
--- a/src/python_bring_api/types.py
+++ b/src/python_bring_api/types.py
@@ -69,3 +69,11 @@ class BringNotificationType(Enum):
     CHANGED_LIST = "CHANGED_LIST"
     SHOPPING_DONE = "SHOPPING_DONE"
     URGENT_MESSAGE = "URGENT_MESSAGE"
+
+class BringRefreshTokenRespone(TypedDict):
+    """A refresh token response class."""
+
+    access_token: str
+    refresh_token: str
+    token_type: str
+    expires_in: int


### PR DESCRIPTION
This is work in progress and far from finished but feedback and help on it is very welcome.

I'm trying to add support for authentication with access token only to make it unnecessary to store the password and to have to login every time the API is called. The access token is valid for 7 days and when it expires it has to be renewed, either by logging in or by using the refresh token. First step was to identify the API Endpoint to refresh the access token. I  added a method to get a new access token. 