### PR TITLE
Add article translation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,20 +39,20 @@ bring.login()
 lists = bring.loadLists()["lists"]
 
 # Save an item with specifications to a certain shopping list
-bring.saveItem(lists[0]['listUuid'], 'Milk', 'low fat')
+bring.saveItem(lists[0]['listUuid'], 'Milk', 'low fat', 'en-GB')
 
 # Save another item
-bring.saveItem(lists[0]['listUuid'], 'Carrots')
+bring.saveItem(lists[0]['listUuid'], 'Carrots', locale='en-GB')
 
 # Get all the items of a list
-items = bring.getItems(lists[0]['listUuid'])
+items = bring.getItems(lists[0]['listUuid'], 'en-GB')
 print(items)
 
 # Check off an item
-bring.completeItem(lists[0]['listUuid'], 'Carrots')
+bring.completeItem(lists[0]['listUuid'], 'Carrots', 'en-GB')
 
 # Remove an item from a list
-bring.removeItem(lists[0]['listUuid'], 'Milk')
+bring.removeItem(lists[0]['listUuid'], 'Milk', 'en-GB')
 ```
 
 ### Async
@@ -78,20 +78,20 @@ async def main():
     lists = (await bring.loadListsAsync())["lists"]
 
     # Save an item with specifications to a certain shopping list
-    await bring.saveItemAsync(lists[0]['listUuid'], 'Milk', 'low fat')
+    await bring.saveItemAsync(lists[0]['listUuid'], 'Milk', 'low fat', 'en-GB')
 
     # Save another item
-    await bring.saveItemAsync(lists[0]['listUuid'], 'Carrots')
+    await bring.saveItemAsync(lists[0]['listUuid'], 'Carrots', locale='en-GB')
 
     # Get all the items of a list
-    items = await bring.getItemsAsync(lists[0]['listUuid'])
+    items = await bring.getItemsAsync(lists[0]['listUuid'], 'en-GB')
     print(items)
 
     # Check off an item
-    await bring.completeItemAsync(lists[0]['listUuid'], 'Carrots')
+    await bring.completeItemAsync(lists[0]['listUuid'], 'Carrots', 'en-GB')
 
     # Remove an item from a list
-    await bring.removeItemAsync(lists[0]['listUuid'], 'Milk')
+    await bring.removeItemAsync(lists[0]['listUuid'], 'Milk', 'en-GB')
 
 asyncio.run(main())
 ```
@@ -126,6 +126,16 @@ You can fix this according to [this](https://stackoverflow.com/questions/6812329
 ```python
 asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 ```
+
+## Locales and article translations
+
+Bring has an extensive article catalog from which users can select when adding an item to their shopping list. However these articles are then translated by the App to Brings default language (de-CH) before submitting any changes to the API. This library handles these translations transparantly if you set the locale argument acordingly when calling its methods.
+
+Each list in Bring can have individual language settings. If you want to get the locale settings from the App, you can use the methods `getUserSettings` and `getUserSettingsAsync`
+
+Currently Bring supports the following locales:
+* en-AU, de-DE, fr-FR, it-IT, en-CA, nl-NL, nb-NO, pl-PL, pt-BR, ru-RU, sv-SE, de-CH, fr-CH, it-CH, es-ES, tr-TR, en-GB, en-US, hu-HU, de-AT
+
 
 ## Changelog
 

--- a/src/python_bring_api/bring.py
+++ b/src/python_bring_api/bring.py
@@ -286,10 +286,16 @@ class Bring:
 
         if locale:
             _translations = await self.getArticleTranslationsAsync(locale)
-            for item in data['purchase']:
-                item['name'] = _translations.get(item['name'], item['name'])
-            for item in data['recently']:
-                item['name'] =_translations.get(item['name'], item['name'])
+            if 'items' in data:
+                for item in data['items']['purchase']:
+                    item['itemId'] = _translations.get(item['itemId'], item['itemId'])
+                for item in data['items']['recently']:
+                    item['itemId'] =_translations.get(item['itemId'], item['itemId'])
+            else:
+                for item in data['purchase']:
+                    item['name'] = _translations.get(item['name'], item['name'])
+                for item in data['recently']:
+                    item['name'] =_translations.get(item['name'], item['name'])
         return data
 
     def getAllItemDetails(self, listUuid: str) -> BringListItemsDetailsResponse:

--- a/src/python_bring_api/bring.py
+++ b/src/python_bring_api/bring.py
@@ -24,7 +24,7 @@ class Bring:
         self.uuid = ''
         self.publicUuid = ''
         self.translations = {}
-
+        self.supported_locales = ['en-AU', 'de-DE', 'fr-FR', 'it-IT','en-CA', 'nl-NL','nb-NO','pl-PL', 'pt-BR', 'ru-RU', 'sv-SE', 'de-CH', 'fr-CH', 'it-CH', 'es-ES', 'tr-TR', 'en-GB', 'en-US', 'hu-HU', 'de-AT']
         self.url = 'https://api.getbring.com/rest/v2/'
         self.url_static = 'https://web.getbring.com/'
 
@@ -786,11 +786,11 @@ class Bring:
                 _LOGGER.debug('Response from %s: %s', url, r.status)
                 r.raise_for_status()
             
-            try:
-                return await r.json()
-            except JSONDecodeError as e:
-                _LOGGER.error(f'Exception: Cannot get user settings for uuid {self.uuid}:\n{traceback.format_exc()}')
-                raise BringParseException('Loading user settings failed during parsing of request response.') from e
+                try:
+                    return await r.json()
+                except JSONDecodeError as e:
+                    _LOGGER.error(f'Exception: Cannot get user settings for uuid {self.uuid}:\n{traceback.format_exc()}')
+                    raise BringParseException('Loading user settings failed during parsing of request response.') from e
         except asyncio.TimeoutError as e:
             _LOGGER.error(f'Exception: Cannot get user settings for uuid {self.uuid}:\n{traceback.format_exc()}')
             raise BringRequestException('Loading user settings failed due to connection timeout.') from e
@@ -854,18 +854,12 @@ class Bring:
             If the request fails.
         BringParseException
             If the parsing of the request response fails.
-       """ 
-        _supported_locales = {
-            'en-AU', 'de-DE', 'fr-FR', 'it-IT','en-CA', 'nl-NL', 
-            'nb-NO','pl-PL', 'pt-BR', 'ru-RU', 'sv-SE', 'de-CH', 
-            'fr-CH', 'it-CH', 'es-ES', 'tr-TR', 'en-GB', 'en-US'
-            'hu-HU', 'de-AT'
-            }
-        if locale not in _supported_locales:
-            _LOGGER.debug('Locale %s not supported by Bring. Ommitting translation.', locale)
-            return {}
-       
-        if locale not in self.translations: 
+       """
+        if locale not in self.supported_locales:
+            _LOGGER.debug('Locale %s not supported by Bring.', locale)
+            raise ValueError(f'Locale {locale} not supported by Bring.')
+
+        if locale not in self.translations:
 
             try:
                 url = f'{self.url_static}locale/articles.{locale}.json'

--- a/src/python_bring_api/bring.py
+++ b/src/python_bring_api/bring.py
@@ -240,12 +240,12 @@ class Bring:
         async def _async():
             async with aiohttp.ClientSession() as session:
                 self._session = session
-                res = await self.getItemsAsync(listUuid)
+                res = await self.getItemsAsync(listUuid, locale)
                 self._session = None
                 return res
         return asyncio.run(_async())
 
-    async def getItemsAsync(self, listUuid: str) -> BringItemsResponse:
+    async def getItemsAsync(self, listUuid: str, locale: str = None) -> BringItemsResponse:
         """
         Get all items from a shopping list.
 
@@ -273,7 +273,7 @@ class Bring:
                 r.raise_for_status()
 
                 try:
-                    return await r.json()
+                    data = await r.json()
                 except JSONDecodeError as e:
                     _LOGGER.error(f'Exception: Cannot get items for list {listUuid}:\n{traceback.format_exc()}')
                     raise BringParseException('Loading list items failed during parsing of request response.') from e
@@ -284,6 +284,13 @@ class Bring:
             _LOGGER.error(f'Exception: Cannot get items for list {listUuid}:\n{traceback.format_exc()}')
             raise BringRequestException('Loading list items failed due to request exception.') from e
 
+        if locale:
+            _translations = await self.getArticleTranslationsAsync(locale)
+            for item in data['purchase']:
+                item['name'] = _translations.get(item['name'], item['name'])
+            for item in data['recently']:
+                item['name'] =_translations.get(item['name'], item['name'])
+        return data
 
     def getAllItemDetails(self, listUuid: str) -> BringListItemsDetailsResponse:
         """
@@ -317,7 +324,7 @@ class Bring:
 
     async def getAllItemDetailsAsync(self, listUuid: str) -> BringItemsResponse:
         """
-        Get all details from a shopping list.
+        Get all details of customized items from a shopping list.
 
         Parameters
         ----------
@@ -329,6 +336,8 @@ class Bring:
         list
             The JSON response as a list. A list of item details.
             Caution: This is NOT a list of the items currently marked as 'to buy'. See getItems() for that.
+            This list contains a lists items that where customized by changing it's default icon, category or uploading
+            an image.
         
         Raises
         ------
@@ -355,7 +364,7 @@ class Bring:
             _LOGGER.error(f'Exception: Cannot get item details for list {listUuid}:\n{traceback.format_exc()}')
             raise BringRequestException('Loading list details failed due to request exception.') from e
 
-    def saveItem(self, listUuid: str, itemName: str, specification='') -> aiohttp.ClientResponse:
+    def saveItem(self, listUuid: str, itemName: str, specification='', locale: str = None) -> aiohttp.ClientResponse:
         """
         Save an item to a shopping list.
 
@@ -381,12 +390,12 @@ class Bring:
         async def _async():
             async with aiohttp.ClientSession() as session:
                 self._session = session
-                res = await self.saveItemAsync(listUuid, itemName, specification)
+                res = await self.saveItemAsync(listUuid, itemName, specification, locale)
                 self._session = None
                 return res
         return asyncio.run(_async())
 
-    async def saveItemAsync(self, listUuid: str, itemName: str, specification='') -> aiohttp.ClientResponse:
+    async def saveItemAsync(self, listUuid: str, itemName: str, specification='', locale: str = None) -> aiohttp.ClientResponse:
         """
         Save an item to a shopping list.
 
@@ -409,6 +418,9 @@ class Bring:
         BringRequestException
             If the request fails.
         """
+        if locale:
+            _translations = await self.getArticleTranslationsAsync(locale, invert=True)
+            itemName = _translations.get(itemName, itemName)
         data = {
             'purchase': itemName,
             'specification': specification,
@@ -427,7 +439,7 @@ class Bring:
             raise BringRequestException(f'Saving item {itemName} ({specification}) to list {listUuid} failed due to request exception.') from e
 
     
-    def updateItem(self, listUuid: str, itemName: str, specification='') -> aiohttp.ClientResponse:
+    def updateItem(self, listUuid: str, itemName: str, specification='', locale: str = None) -> aiohttp.ClientResponse:
         """
         Update an existing list item.
 
@@ -453,12 +465,12 @@ class Bring:
         async def _async():
             async with aiohttp.ClientSession() as session:
                 self._session = session
-                res = await self.updateItemAsync(listUuid, itemName, specification)
+                res = await self.updateItemAsync(listUuid, itemName, specification, locale)
                 self._session = None
                 return res
         return asyncio.run(_async())
 
-    async def updateItemAsync(self, listUuid: str, itemName: str, specification='') -> aiohttp.ClientResponse:
+    async def updateItemAsync(self, listUuid: str, itemName: str, specification='', locale: str = None) -> aiohttp.ClientResponse:
         """
         Update an existing list item.
 
@@ -481,6 +493,9 @@ class Bring:
         BringRequestException
             If the request fails.
         """
+        if locale:
+            _translations = await self.getArticleTranslationsAsync(locale, invert=True)
+            itemName = _translations.get(itemName, itemName)
         data = {
             'purchase': itemName,
             'specification': specification
@@ -499,7 +514,7 @@ class Bring:
             raise BringRequestException(f'Updating item {itemName} ({specification}) in list {listUuid} failed due to request exception.') from e
 
     
-    def removeItem(self, listUuid: str, itemName: str) -> aiohttp.ClientResponse:
+    def removeItem(self, listUuid: str, itemName: str, locale: str = None) -> aiohttp.ClientResponse:
         """
         Remove an item from a shopping list.
 
@@ -523,12 +538,12 @@ class Bring:
         async def _async():
             async with aiohttp.ClientSession() as session:
                 self._session = session
-                res = await self.removeItemAsync(listUuid, itemName)
+                res = await self.removeItemAsync(listUuid, itemName, locale)
                 self._session = None
                 return res
         return asyncio.run(_async())
 
-    async def removeItemAsync(self, listUuid: str, itemName: str) -> aiohttp.ClientResponse:
+    async def removeItemAsync(self, listUuid: str, itemName: str, locale: str = None) -> aiohttp.ClientResponse:
         """
         Remove an item from a shopping list.
 
@@ -549,6 +564,9 @@ class Bring:
         BringRequestException
             If the request fails.
         """
+        if locale:
+            _translations = await self.getArticleTranslationsAsync(locale, invert=True)
+            itemName = _translations.get(itemName, itemName)
         data = {
             'remove': itemName,
         }
@@ -565,7 +583,7 @@ class Bring:
             _LOGGER.error(f'Exception: Cannot remove item {itemName} to list {listUuid}:\n{traceback.format_exc()}')
             raise BringRequestException(f'Removing item {itemName} from list {listUuid} failed due to request exception.') from e
 
-    def completeItem(self, listUuid: str, itemName: str) -> aiohttp.ClientResponse:
+    def completeItem(self, listUuid: str, itemName: str, locale: str = None) -> aiohttp.ClientResponse:
         """
         Complete an item from a shopping list. This will add it to recent items.
         If it was not on the list, it will still be added to recent items.
@@ -590,13 +608,13 @@ class Bring:
         async def _async():
             async with aiohttp.ClientSession() as session:
                 self._session = session
-                res = await self.completeItemAsync(listUuid, itemName)
+                res = await self.completeItemAsync(listUuid, itemName, locale)
                 self._session = None
                 return res
         return asyncio.run(_async())
 
 
-    async def completeItemAsync(self, listUuid: str, itemName: str) -> aiohttp.ClientResponse:
+    async def completeItemAsync(self, listUuid: str, itemName: str, locale: str = None) -> aiohttp.ClientResponse:
         """
         Complete an item from a shopping list. This will add it to recent items.
         If it was not on the list, it will still be added to recent items.
@@ -618,6 +636,9 @@ class Bring:
         BringRequestException
             If the request fails.
         """
+        if locale:
+            _translations = await self.getArticleTranslationsAsync(locale, invert=True)
+            itemName = _translations.get(itemName, itemName)
         data = {
             'recently': itemName
         }
@@ -734,18 +755,48 @@ class Bring:
         BringParseException
             If the parsing of the request response fails.
         """
-        try:
-            r = requests.get(f'{self.url}bringusersettings/{self.uuid}', headers = self.headers)
-            r.raise_for_status()
-        except RequestException as e:
-            _LOGGER.error(f'Exception: Cannot get user settings:\n{traceback.format_exc()}')
-            raise BringRequestException(f'Loading user settings failed due to request exception.') from e
+        async def _async():
+            async with aiohttp.ClientSession() as session:
+                self._session = session
+                res = await self.getUserSettingsAsync()
+                self._session = None
+                return res
+        return asyncio.run(_async())
+
+    async def getUserSettingsAsync(self) -> BringUserSettingsResponse:
+        """
+        Load user settings and user list settings.
+
+        Returns
+        -------
+        dict
+            The JSON response as a dict.
         
+
+        Raises
+        ------
+        BringRequestException
+            If the request fails.
+        BringParseException
+            If the parsing of the request response fails.
+        """
         try:
-            return r.json()
-        except JSONDecodeError as e:
-            _LOGGER.error(f'Exception: Cannot get user settings:\n{traceback.format_exc()}')
-            raise BringParseException(f'Loading user settings failed during parsing of request response.') from e
+            url = f'{self.url}bringusersettings/{self.uuid}'
+            async with self._session.get(url, headers=self.headers) as r:
+                _LOGGER.debug('Response from %s: %s', url, r.status)
+                r.raise_for_status()
+            
+            try:
+                return await r.json()
+            except JSONDecodeError as e:
+                _LOGGER.error(f'Exception: Cannot get user settings for uuid {self.uuid}:\n{traceback.format_exc()}')
+                raise BringParseException('Loading user settings failed during parsing of request response.') from e
+        except asyncio.TimeoutError as e:
+            _LOGGER.error(f'Exception: Cannot get user settings for uuid {self.uuid}:\n{traceback.format_exc()}')
+            raise BringRequestException('Loading user settings failed due to connection timeout.') from e
+        except aiohttp.ClientError as e:
+            _LOGGER.error(f'Exception: Cannot get user settings for uuid {self.uuid}:\n{traceback.format_exc()}')
+            raise BringRequestException('Loading user settings failed due to request exception.') from e
 
 
     def getArticleTranslations(self, locale: str, invert: bool = False) -> Dict:
@@ -772,19 +823,68 @@ class Bring:
         BringParseException
             If the parsing of the request response fails.
        """ 
+        async def _async():
+            async with aiohttp.ClientSession() as session:
+                self._session = session
+                res = await self.getArticleTranslationsAsync(locale, invert)
+                self._session = None
+                return res
+        return asyncio.run(_async())
+
+    async def getArticleTranslationsAsync(self, locale: str, invert: bool = False) -> Dict:
+        """
+        Get articles translation table.
+        
+        Parameters
+        ----------
+        locale : str
+           locale of the translation table.
+        invert : str
+            Return the translation table inverted.
+        
+       Returns
+        -------
+        dict
+            The JSON response as a dict.
+        
+
+        Raises
+        ------
+        BringRequestException
+            If the request fails.
+        BringParseException
+            If the parsing of the request response fails.
+       """ 
+        _supported_locales = {
+            'en-AU', 'de-DE', 'fr-FR', 'it-IT','en-CA', 'nl-NL', 
+            'nb-NO','pl-PL', 'pt-BR', 'ru-RU', 'sv-SE', 'de-CH', 
+            'fr-CH', 'it-CH', 'es-ES', 'tr-TR', 'en-GB', 'en-US'
+            'hu-HU', 'de-AT'
+            }
+        if locale not in _supported_locales:
+            _LOGGER.debug('Locale %s not supported by Bring. Ommitting translation.', locale)
+            return {}
+       
         if locale not in self.translations: 
 
             try:
-                r = requests.get(f'{self.url_static}locale/articles.{locale}.json')
-                r.raise_for_status()
-            except RequestException as e:
+                url = f'{self.url_static}locale/articles.{locale}.json'
+                async with self._session.get(url) as r:
+                    _LOGGER.debug('Response from %s: %s', url, r.status)
+                    r.raise_for_status()
+
+                    try:
+                        self.translations[locale] = await r.json()
+                    except JSONDecodeError as e:
+                        _LOGGER.error(f'Exception: Cannot load articles.{locale}.json:\n{traceback.format_exc()}')
+                        raise BringParseException(f'Loading article translations for locale {locale} failed during parsing of request response.') from e
+            except asyncio.TimeoutError as e:
+                _LOGGER.error(f'Exception: Cannot load articles.{locale}.json::\n{traceback.format_exc()}')
+                raise BringRequestException('Loading article translations for locale {locale} failed due to connection timeout.') from e
+               
+            except aiohttp.ClientError as e:
                 _LOGGER.error(f'Exception: Cannot load articles.{locale}.json:\n{traceback.format_exc()}')
                 raise BringRequestException(f'Loading article translations for locale {locale} failed due to request exception.') from e
             
-            try:
-                self.translations[locale] = r.json()
-            except JSONDecodeError as e:
-                _LOGGER.error(f'Exception: Cannot load articles.{locale}.json:\n{traceback.format_exc()}')
-                raise BringParseException(f'Loading article translations for locale {locale} failed during parsing of request response.') from e
-        
+
         return {value:key for key, value in self.translations[locale].items()} if invert else self.translations[locale]

--- a/src/python_bring_api/bring.py
+++ b/src/python_bring_api/bring.py
@@ -336,7 +336,7 @@ class Bring:
         list
             The JSON response as a list. A list of item details.
             Caution: This is NOT a list of the items currently marked as 'to buy'. See getItems() for that.
-            This list contains a lists items that where customized by changing it's default icon, category or uploading
+            This contains a list of items that where customized by changing their default icon, category or uploading
             an image.
         
         Raises

--- a/src/python_bring_api/types.py
+++ b/src/python_bring_api/types.py
@@ -69,3 +69,18 @@ class BringNotificationType(Enum):
     CHANGED_LIST = "CHANGED_LIST"
     SHOPPING_DONE = "SHOPPING_DONE"
     URGENT_MESSAGE = "URGENT_MESSAGE"
+
+class BringUserSettings(TypedDict):
+    """A user settings class. Represents a single user setting."""
+    key: str
+    value: str
+
+class BringUserListSettings(TypedDict):
+    """A user list settings class. Represents a single list setting."""
+    listUuid: str
+    usersettings: List[BringUserSettings]
+
+class BringUserSettingsResponse(TypedDict):
+    """A user settings response class."""
+    usersettings: List[BringUserSettings]
+    userlistsettings: List[BringUserListSettings]


### PR DESCRIPTION
Adds a method to get article translations and load article translation table if it is not already downloaded. Methods for sending and receiving articles from and to the Bring API have been extended to translate article names if a locale has been provided as argument. Also adds a method to get user settings, which includes also language settings for each list.

