### PR TITLE
add missing recently list type

### DIFF
--- a/src/python_bring_api/types.py
+++ b/src/python_bring_api/types.py
@@ -52,6 +52,7 @@ class BringItemsResponse(TypedDict):
     uuid: str
     status: str
     purchase: List[BringPurchase]
+    recently: List[BringPurchase]
 
 class BringListItemsDetailsResponse(List[BringListItemDetails]):
     """A response class of a list of item details."""


### PR DESCRIPTION
The `recently` items became relevant since the implementation of the `complete` and `completeAsync` method by @tr4nt0r , but it is not reflected in the types yet.