### PR TITLE
Add catalog-based item name resolution for icon support

### DIFF
--- a/src/python_bring_api/bring.py
+++ b/src/python_bring_api/bring.py
@@ -23,6 +23,7 @@ class Bring:
         self.password = password
         self.uuid = ''
         self.publicUuid = ''
+        self._catalog = {}  # maps lowercase localized name -> German itemId
 
         self.url = 'https://api.getbring.com/rest/v2/'
 
@@ -213,6 +214,89 @@ class Bring:
         except aiohttp.ClientError as e:
             _LOGGER.error(f'Exception: Cannot get lists:\n{traceback.format_exc()}')
             raise BringRequestException('Loading lists failed due to request exception.') from e
+
+    def loadCatalog(self, locale: str) -> dict:
+        """Load the article catalog for a given locale and build a translation map
+        from localized item names to internal item IDs. This enables icons to be
+        displayed when saving items via the API.
+
+        Call this once after login, before saving items.
+
+        Parameters
+        ----------
+        locale : str
+            The locale identifier (e.g. 'en-US', 'de-DE', 'fr-FR').
+
+        Returns
+        -------
+        dict
+            The raw catalog response.
+
+        Raises
+        ------
+        BringRequestException
+            If the request fails.
+        BringParseException
+            If the parsing of the request response fails.
+        """
+        async def _async():
+            async with aiohttp.ClientSession() as session:
+                self._session = session
+                res = await self.loadCatalogAsync(locale)
+                self._session = None
+                return res
+        return asyncio.run(_async())
+
+    async def loadCatalogAsync(self, locale: str) -> dict:
+        """Load the article catalog for a given locale and build a translation map
+        from localized item names to internal item IDs. This enables icons to be
+        displayed when saving items via the API.
+
+        Call this once after login, before saving items.
+
+        Parameters
+        ----------
+        locale : str
+            The locale identifier (e.g. 'en-US', 'de-DE', 'fr-FR').
+
+        Returns
+        -------
+        dict
+            The raw catalog response.
+
+        Raises
+        ------
+        BringRequestException
+            If the request fails.
+        BringParseException
+            If the parsing of the request response fails.
+        """
+        try:
+            url = f'https://web.getbring.com/locale/catalog.{locale}.json'
+            async with self._session.get(url) as r:
+                _LOGGER.debug(f'Response from %s: %s', url, r.status)
+                r.raise_for_status()
+
+                try:
+                    data = await r.json()
+                except JSONDecodeError as e:
+                    _LOGGER.error(f'Exception: Cannot get catalog:\n{traceback.format_exc()}')
+                    raise BringParseException(f'Loading catalog failed during parsing of request response.') from e
+        except asyncio.TimeoutError as e:
+            _LOGGER.error(f'Exception: Cannot get catalog:\n{traceback.format_exc()}')
+            raise BringRequestException('Loading catalog failed due to connection timeout.') from e
+        except aiohttp.ClientError as e:
+            _LOGGER.error(f'Exception: Cannot get catalog:\n{traceback.format_exc()}')
+            raise BringRequestException('Loading catalog failed due to request exception.') from e
+
+        self._catalog = {}
+        for section in data.get('catalog', {}).get('sections', []):
+            for item in section.get('items', []):
+                self._catalog[item['name'].lower()] = item['itemId']
+                # Also map the itemId itself so German names pass through
+                self._catalog[item['itemId'].lower()] = item['itemId']
+
+        return data
 
     def getItems(self, listUuid: str) -> BringItemsResponse:
         """
@@ -407,8 +491,10 @@ class Bring:
         BringRequestException
             If the request fails.
         """
+        # Resolve to catalog itemId for icon support, fall back to original name
+        purchase = self._catalog.get(itemName.lower(), itemName)
         data = {
-            'purchase': itemName,
+            'purchase': purchase,
             'specification': specification,
         }
         try:
@@ -480,7 +566,7 @@ class Bring:
             If the request fails.
         """
         data = {
-            'purchase': itemName,
+            'purchase': self._catalog.get(itemName.lower(), itemName),
             'specification': specification
         }
         try:
@@ -548,7 +634,7 @@ class Bring:
             If the request fails.
         """
         data = {
-            'remove': itemName,
+            'remove': self._catalog.get(itemName.lower(), itemName),
         }
         try:
             url = f'{self.url}bringlists/{listUuid}'
@@ -617,7 +703,7 @@ class Bring:
             If the request fails.
         """
         data = {
-            'recently': itemName
+            'recently': self._catalog.get(itemName.lower(), itemName)
         }
         try:
             url = f'{self.url}bringlists/{listUuid}'

--- a/src/python_bring_api/bring.py
+++ b/src/python_bring_api/bring.py
@@ -24,6 +24,7 @@ class Bring:
         self.uuid = ''
         self.publicUuid = ''
         self._catalog = {}  # maps lowercase localized name -> German itemId
+        self._catalog_reverse = {}  # maps lowercase German itemId -> localized name
 
         self.url = 'https://api.getbring.com/rest/v2/'
 
@@ -290,11 +291,14 @@ class Bring:
             raise BringRequestException('Loading catalog failed due to request exception.') from e
 
         self._catalog = {}
+        self._catalog_reverse = {}
         for section in data.get('catalog', {}).get('sections', []):
             for item in section.get('items', []):
                 self._catalog[item['name'].lower()] = item['itemId']
                 # Also map the itemId itself so German names pass through
                 self._catalog[item['itemId'].lower()] = item['itemId']
+                # Reverse: German itemId -> localized name
+                self._catalog_reverse[item['itemId'].lower()] = item['name']
 
         return data
 
@@ -355,10 +359,19 @@ class Bring:
                 r.raise_for_status()
 
                 try:
-                    return await r.json()
+                    data = await r.json()
                 except JSONDecodeError as e:
                     _LOGGER.error(f'Exception: Cannot get items for list {listUuid}:\n{traceback.format_exc()}')
                     raise BringParseException('Loading list items failed during parsing of request response.') from e
+
+                # Translate German item IDs back to localized names
+                if self._catalog_reverse:
+                    for item in data.get('purchase', []):
+                        item['name'] = self._catalog_reverse.get(item['name'].lower(), item['name'])
+                    for item in data.get('recently', []):
+                        item['name'] = self._catalog_reverse.get(item['name'].lower(), item['name'])
+
+                return data
         except asyncio.TimeoutError as e:
             _LOGGER.error(f'Exception: Cannot get items for list {listUuid}:\n{traceback.format_exc()}')
             raise BringRequestException('Loading list items failed due to connection timeout.') from e

--- a/test_icon.py
+++ b/test_icon.py
@@ -1,0 +1,38 @@
+"""Test the catalog-based icon resolution via the library.
+
+Set BRING_EMAIL and BRING_PASSWORD environment variables before running.
+"""
+import asyncio
+import aiohttp
+import os
+import sys
+sys.path.insert(0, 'src')
+from python_bring_api.bring import Bring
+
+MAIL = os.environ['BRING_EMAIL']
+PASSWORD = os.environ['BRING_PASSWORD']
+
+async def main():
+    async with aiohttp.ClientSession() as session:
+        bring = Bring(MAIL, PASSWORD, sessionAsync=session)
+        await bring.loginAsync()
+        print("Logged in")
+
+        lists = await bring.loadListsAsync()
+        list_uuid = lists['lists'][0]['listUuid']
+        print(f"Using list: {lists['lists'][0]['name']}")
+
+        # Load catalog for icon support
+        await bring.loadCatalogAsync('en-US')
+        print(f"Catalog loaded: {len(bring._catalog)} entries")
+
+        # Save item using English name - should auto-resolve and show icon
+        await bring.saveItemAsync(list_uuid, 'Pineapple', 'via catalog')
+        print("Saved 'Pineapple' (should show with pineapple icon)")
+
+        # Wait a bit so you can check the app, then clean up
+        await asyncio.sleep(5)
+        await bring.removeItemAsync(list_uuid, 'Pineapple')
+        print("Removed 'Pineapple'")
+
+asyncio.run(main())

--- a/test_icon.py
+++ b/test_icon.py
@@ -28,9 +28,14 @@ async def main():
 
         # Save item using English name - should auto-resolve and show icon
         await bring.saveItemAsync(list_uuid, 'Pineapple', 'via catalog')
-        print("Saved 'Pineapple' (should show with pineapple icon)")
+        print("Saved 'Pineapple'")
 
-        # Wait a bit so you can check the app, then clean up
+        # Read back - should return English names
+        items = await bring.getItemsAsync(list_uuid)
+        for p in items.get('purchase', []):
+            print(f"  Item: {p['name']} ({p['specification']})")
+
+        # Clean up
         await asyncio.sleep(5)
         await bring.removeItemAsync(list_uuid, 'Pineapple')
         print("Removed 'Pineapple'")


### PR DESCRIPTION
When items are added via the API using localized names (e.g. "Pineapple"), Bring doesn't show icons. The fix is to resolve item names to their internal German catalog IDs (e.g. "Ananas") which triggers icon display. The app translates these back to the user's locale automatically.

Call loadCatalog(locale) once after login to enable this. Items not found in the catalog fall back to the original name.